### PR TITLE
Add missing dependency check to Minecraft example

### DIFF
--- a/examples/Minecraft/CMakeLists.txt
+++ b/examples/Minecraft/CMakeLists.txt
@@ -2,7 +2,7 @@ set(APP_NAME Minecraft)
 
 project(${APP_NAME})
 
-if(NOT TARGET geUtil OR NOT TARGET geGL)
+if(NOT TARGET geUtil OR NOT TARGET geGL OR NOT TARGET SDLWindow)
    return()
 endif()
 


### PR DESCRIPTION
When not building the addons (geAd), the Minecraft example still gets configured. Later, the build fails on missing `geAd/Export.h` header:

```
.../geAd/SDLWindow/SDLWindow.h:9:9: fatal error: geAd/Export.h: No such file or directory
 #include<geAd/Export.h>
```

This PR adds check for `SDLWindow` target to the appropriate `CMakeLists.txt`, which disables the example when the geAd component is not built.