### PR TITLE
Link with assimp target

### DIFF
--- a/geAd/AssimpModelLoader/cmake/AssimpModelLoaderConfig.cmake
+++ b/geAd/AssimpModelLoader/cmake/AssimpModelLoaderConfig.cmake
@@ -49,8 +49,4 @@ add_library(${MODULE_NAME} INTERFACE )
 target_sources(${MODULE_NAME} INTERFACE ${${MODULE_NAME}_SOURCE_FILES})
 target_include_directories(${MODULE_NAME} INTERFACE "${MODULE_DIR}/src/" ${ASSIMP_INCLUDE_DIRS})
 #set_property(TARGET geGL APPEND PROPERTY INTERFACE_LINK_LIBRARIES "${${_dep}_LIBRARY}")
-target_link_libraries(${MODULE_NAME} INTERFACE ste geSG glm)
-                        
-target_link_libraries(${MODULE_NAME} INTERFACE optimized ${ASSIMP_LIBRARY_DIRS}/assimp.lib
-                        debug ${ASSIMP_LIBRARY_DIRS}/assimpd.lib
-)
+target_link_libraries(${MODULE_NAME} INTERFACE ste geSG glm assimp)


### PR DESCRIPTION
Currently, the AssimpModelLoader add-on tries to link with library files named `assimp.lib` and `assimpd.lib`, which are not present in my (ArchLinux) installation of assimp library.

Curiously, the CMake modules in the repository contains custom `FindAssimp.cmake` module, which *does work* (produces valid target for linking). For some reason, the AssimpModelLoader does not use that.

This PR changes the `target_link_libraries` command for the Loader to utilize the found target.